### PR TITLE
Temporary removal of 2023 from roadmap

### DIFF
--- a/content/roadmap.md
+++ b/content/roadmap.md
@@ -247,8 +247,10 @@ Wrapped Banano on Ethereum. BananoPie launch (community project).
 
 Wrapped Banano on Arbitrum. Christmas Reddit airdrops.
 
+<!--
 ## 2023
 
 ### January
 
 Wrapped Banano dApp update, Zaps support.
+-->


### PR DESCRIPTION
Roadmap for 2023 currently renders weird with only a single month. This PR removes 2023 from the roadmap for now. 